### PR TITLE
extract_summary() should return factors when sensible

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,4 +56,4 @@ Config/Needs/website: pkgdown, tidymodels, tidyverse, palmerpenguins, patchwork,
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0.9000
+RoxygenNote: 7.2.1.9000

--- a/R/extract_summary.R
+++ b/R/extract_summary.R
@@ -58,6 +58,12 @@ extract_fit_summary.kmeans <- function(object, ...) {
 extract_fit_summary.KMeansCluster <- function(object, ...) {
   reorder_clusts <- order(unique(object$cluster))
   names <- paste0("Cluster_", seq_len(nrow(object$centroids)))
+  names <- factor(names)
+
+  cluster_asignments <- factor(
+    names[reorder_clusts][object$clusters],
+    levels = levels(names)
+  )
 
   list(
     cluster_names = names,
@@ -66,7 +72,7 @@ extract_fit_summary.KMeansCluster <- function(object, ...) {
     within_sse = object$WCSS_per_cluster[reorder_clusts],
     tot_sse = object$total_SSE,
     orig_labels = object$clusters,
-    cluster_assignments = names[reorder_clusts][object$clusters]
+    cluster_assignments = cluster_asignments
   )
 }
 

--- a/R/extract_summary.R
+++ b/R/extract_summary.R
@@ -1,10 +1,13 @@
-
 #' S3 method to get fitted model summary info depending on engine
 #'
 #' @param object a fitted cluster_spec object
 #' @param ... other arguments passed to methods
 #'
 #' @return A list with various summary elements
+#'
+#' @details
+#'
+#' The elements `cluster_names` and `cluster_assignments` will be factors.
 #'
 #' @examples
 #' kmeans_spec <- k_means(num_clusters = 5) %>%

--- a/R/extract_summary.R
+++ b/R/extract_summary.R
@@ -33,6 +33,12 @@ extract_fit_summary.workflow <- function(object, ...) {
 extract_fit_summary.kmeans <- function(object, ...) {
   reorder_clusts <- order(unique(object$cluster))
   names <- paste0("Cluster_", seq_len(nrow(object$centers)))
+  names <- factor(names)
+
+  cluster_asignments <- factor(
+    names[reorder_clusts][object$cluster],
+    levels = levels(names)
+  )
 
   list(
     cluster_names = names,
@@ -41,7 +47,7 @@ extract_fit_summary.kmeans <- function(object, ...) {
     within_sse = object$withinss[reorder_clusts],
     tot_sse = object$totss,
     orig_labels = unname(object$cluster),
-    cluster_assignments = names[reorder_clusts][object$cluster]
+    cluster_assignments = cluster_asignments
   )
 }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,6 +39,7 @@ The first thing you do is to create a `cluster specification`. For this example 
 
 ```{r}
 library(tidyclust)
+set.seed(1234)
 
 kmeans_spec <- k_means(num_clusters = 3) %>%
   set_engine("stats") 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ example we are creating a K-means model, using the `stats` engine.
 
 ``` r
 library(tidyclust)
+set.seed(1234)
 
 kmeans_spec <- k_means(num_clusters = 3) %>%
   set_engine("stats") 
@@ -56,38 +57,38 @@ kmeans_spec_fit <- kmeans_spec %>%
 kmeans_spec_fit
 #> tidyclust cluster object
 #> 
-#> K-means clustering with 3 clusters of sizes 11, 7, 14
+#> K-means clustering with 3 clusters of sizes 7, 14, 11
 #> 
 #> Cluster means:
 #>        mpg cyl     disp        hp     drat       wt     qsec        vs
-#> 1 26.66364   4 105.1364  82.63636 4.070909 2.285727 19.13727 0.9090909
-#> 2 19.74286   6 183.3143 122.28571 3.585714 3.117143 17.97714 0.5714286
-#> 3 15.10000   8 353.1000 209.21429 3.229286 3.999214 16.77214 0.0000000
+#> 1 19.74286   6 183.3143 122.28571 3.585714 3.117143 17.97714 0.5714286
+#> 2 15.10000   8 353.1000 209.21429 3.229286 3.999214 16.77214 0.0000000
+#> 3 26.66364   4 105.1364  82.63636 4.070909 2.285727 19.13727 0.9090909
 #>          am     gear     carb
-#> 1 0.7272727 4.090909 1.545455
-#> 2 0.4285714 3.857143 3.428571
-#> 3 0.1428571 3.285714 3.500000
+#> 1 0.4285714 3.857143 3.428571
+#> 2 0.1428571 3.285714 3.500000
+#> 3 0.7272727 4.090909 1.545455
 #> 
 #> Clustering vector:
 #>           Mazda RX4       Mazda RX4 Wag          Datsun 710      Hornet 4 Drive 
-#>                   2                   2                   1                   2 
+#>                   1                   1                   3                   1 
 #>   Hornet Sportabout             Valiant          Duster 360           Merc 240D 
-#>                   3                   2                   3                   1 
+#>                   2                   1                   2                   3 
 #>            Merc 230            Merc 280           Merc 280C          Merc 450SE 
-#>                   1                   2                   2                   3 
+#>                   3                   1                   1                   2 
 #>          Merc 450SL         Merc 450SLC  Cadillac Fleetwood Lincoln Continental 
-#>                   3                   3                   3                   3 
+#>                   2                   2                   2                   2 
 #>   Chrysler Imperial            Fiat 128         Honda Civic      Toyota Corolla 
-#>                   3                   1                   1                   1 
+#>                   2                   3                   3                   3 
 #>       Toyota Corona    Dodge Challenger         AMC Javelin          Camaro Z28 
-#>                   1                   3                   3                   3 
+#>                   3                   2                   2                   2 
 #>    Pontiac Firebird           Fiat X1-9       Porsche 914-2        Lotus Europa 
-#>                   3                   1                   1                   1 
+#>                   2                   3                   3                   3 
 #>      Ford Pantera L        Ferrari Dino       Maserati Bora          Volvo 142E 
-#>                   3                   2                   3                   1 
+#>                   2                   1                   2                   3 
 #> 
 #> Within cluster sum of squares by cluster:
-#> [1] 11848.37 13954.34 93643.90
+#> [1] 13954.34 93643.90 11848.37
 #>  (between_SS / total_SS =  80.8 %)
 #> 
 #> Available components:
@@ -137,7 +138,7 @@ and `extract_centroids()` returns the locations of the clusters
 extract_centroids(kmeans_spec_fit)
 #> # A tibble: 3 × 12
 #>   .cluster    mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
-#>   <chr>     <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+#>   <fct>     <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
 #> 1 Cluster_1  19.7     6  183. 122.   3.59  3.12  18.0 0.571 0.429  3.86  3.43
 #> 2 Cluster_2  26.7     4  105.  82.6  4.07  2.29  19.1 0.909 0.727  4.09  1.55
 #> 3 Cluster_3  15.1     8  353. 209.   3.23  4.00  16.8 0     0.143  3.29  3.5

--- a/man/extract_fit_summary.Rd
+++ b/man/extract_fit_summary.Rd
@@ -17,6 +17,9 @@ A list with various summary elements
 \description{
 S3 method to get fitted model summary info depending on engine
 }
+\details{
+The elements \code{cluster_names} and \code{cluster_assignments} will be factors.
+}
 \examples{
 kmeans_spec <- k_means(num_clusters = 5) \%>\%
   set_engine("stats")

--- a/tests/testthat/test-extract_summary.R
+++ b/tests/testthat/test-extract_summary.R
@@ -14,6 +14,9 @@ test_that("extract summary works for kmeans", {
 
   # check order
   expect_equal(summ1$n_members, c(17, 11, 4))
+
+  expect_true(is.factor(summ1$cluster_names))
+  expect_true(is.factor(summ1$cluster_assignments))
 })
 
 test_that("extract summary works for kmeans when num_clusters = 1", {

--- a/tests/testthat/test-extract_summary.R
+++ b/tests/testthat/test-extract_summary.R
@@ -17,6 +17,9 @@ test_that("extract summary works for kmeans", {
 
   expect_true(is.factor(summ1$cluster_names))
   expect_true(is.factor(summ1$cluster_assignments))
+
+  expect_true(is.factor(summ2$cluster_names))
+  expect_true(is.factor(summ2$cluster_assignments))
 })
 
 test_that("extract summary works for kmeans when num_clusters = 1", {

--- a/tests/testthat/test-extract_summary.R
+++ b/tests/testthat/test-extract_summary.R
@@ -44,3 +44,14 @@ test_that("extract summary works for kmeans when num_clusters = 1", {
     tibble::as_tibble(lapply(mtcars, mean))
   )
 })
+
+test_that("extract summary works for hier_clust", {
+  obj1 <- tidyclust::hier_clust(num_clusters = 4) %>%
+    fit(~., mtcars)
+
+  summ1 <- extract_fit_summary(obj1)
+
+  expect_true(is.factor(summ1$cluster_names))
+  expect_true(is.factor(summ1$cluster_assignments))
+
+})


### PR DESCRIPTION
To close https://github.com/EmilHvitfeldt/tidyclust/issues/73

``` r
library(tidyverse)
library(tidyclust)

kmeans_spec <- k_means(num_clusters = 4)
kmeans_spec_fit <- kmeans_spec |> 
  fit(~., data = mtcars)

extract_centroids(kmeans_spec_fit) |> 
  pull(.cluster) |> class()
#> [1] "factor"

extract_cluster_assignment(kmeans_spec_fit) |> 
  pull(.cluster) |> class()
#> [1] "factor"
```

<sup>Created on 2022-08-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>